### PR TITLE
Исправления код стайла

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ class MyClass: BaseClass {
     // MARK: - Constants
     
     private enum Constants {
-        static let isUsingLasers: Bool = true
+    	static let isUsingLasers: Bool = true
 	static let animationTime: TimeInterval = 0.3
     }
     

--- a/README.md
+++ b/README.md
@@ -238,6 +238,18 @@ enum Direction {
 ```swift
 
 class MyClass: BaseClass {
+
+    // MARK: - Constants
+    
+    private enum Constants {
+        static let isUsingLasers: Bool = true
+	static let animationTime: TimeInterval = 0.3
+    }
+    
+    // MARK: - Properties 
+    
+    var citySelected: PublishSubject<City>? = nil
+    var text: String { get { ... } set { ... } }
     
     // MARK: - IBOutlets
     
@@ -246,15 +258,10 @@ class MyClass: BaseClass {
     // MARK: - NSLayoutConstraints
     
     @IBOutlet private weak var titleLabelTopConstraint: NSLayoutConstraint!
-
-    // MARK: - Constants
     
-    private let isUsingLasers = true
+    // MARK: - IBActions
     
-    // MARK: - Properties 
-    
-    var citySelected: PublishSubject<City>? = nil
-    var text: String { get { ... } set { ... } }
+    @IBaction private func cancel(_ sender: UIButton) { ... }
     
     // MARK: - Initialization and deinitialization
     
@@ -400,8 +407,8 @@ var notSoObviouslyFloat: CGFloat = 13.012
 
 ```swift
 enum Colors {
-    static let CustomRed = UIColor(red: 250/255.0, green: 15/255.0, blue: 20/255.0, alpha: 1.0)
-    static let CustomBlue = UIColor(red: 10/255.0, green: 0, blue: 200/255.0, alpha: 1.0)
+    static let customRed = UIColor(red: 250 / 255.0, green: 15 / 255.0, blue: 20 / 255.0, alpha: 1.0)
+    static let customBlue = UIColor(red: 10 / 255.0, green: 0, blue: 200 / 255.0, alpha: 1.0)
 }
 ```
 
@@ -411,12 +418,21 @@ enum Colors {
 
 ```swift
 class MyView : UIView {
-    @IBOutlet var button : UIButton!
+
+    // MARK: - IBOutlets
+
+    @IBOutlet private var button : UIButton!
+
+    // MARK: - Properties
+
     var buttonOriginalWidth : CGFloat!
+
+    // MARK: - UIView
 
     override func awakeFromNib() {
         self.buttonOriginalWidth = self.button.frame.size.width
     }
+
 }
 ```
 


### PR DESCRIPTION
**Изменения:**
- Обновил раздел "Структура класса"
- Исправил синтаксис внутри enum

**Замечания:**
Я думаю мы можем поменять или совсем убрать вот этот кусок: 
> * Не использовать `!` при объявлении переменных! Исключений всего 2: это взаимодействие с Objective-C кодом и невозможность вычислить инициализирующее значения до достижения некоторых условий. Например, нельзя прочитать `frame` некоторой `UIView` до того, как она загружена из `xib`:

Почему? Потому что во втором случае можно сделать optional, а в нужном месте загвардить. И не надо будет для наших правил SwiftLint выключение-включение делать.